### PR TITLE
fix trailing slash in README.md Installation/Linux 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ On Linux, you can install them like so:
 
 ```shell
 $ curl -L -o /tmp/stfs "https://github.com/pojntfx/stfs/releases/latest/download/stfs.linux-$(uname -m)"
-$ sudo install /tmp/stfs /usr/local/bin
+$ sudo install /tmp/stfs /usr/local/bin/
 ```
 
 On macOS, you can use the following:


### PR DESCRIPTION
gnu utils have different trailing slash behavior